### PR TITLE
Fix typo in reusable form documentation

### DIFF
--- a/docs/published/how-to-create-a-reusable-form.md
+++ b/docs/published/how-to-create-a-reusable-form.md
@@ -41,6 +41,6 @@ The components being used in different `+page.svelte`
 
 ## Why repeat the form action on multiple endpoints instead of reusing the endpoint
 
-For progressive anhancement and support for `form` prop.
+For progressive enhancement and support for `form` prop.
 
 Form actions are built on top of native forms, on submission, users are redirected to the page the form action is on [[src]](https://svelte.dev/docs/kit/form-actions#Progressive-enhancement-use:enhance). By reusing the same endpoint, users without Javascript enabled may be redirected to routes without a `+page.svelte`.

--- a/docs/published/what-is-full-stack.md
+++ b/docs/published/what-is-full-stack.md
@@ -6,7 +6,7 @@ tags:
 
 ![alt text](what-is-full-stack.svg)
 
-The word full-stack lacks naunace and dscriptiveness. As meta-frameworks become more popular other words like front-frontend and front-backend came into circulation. More and more, frontend devs find themselves working on projects and tasks they have no expertise in. In the graph above, I attempt to provide a visualization and a language to give power back to devs to communicate what it is exactly that they do.
+The word full-stack lacks naunace and descriptiveness. As meta-frameworks become more popular other words like front-frontend and front-backend came into circulation. More and more, frontend devs find themselves working on projects and tasks they have no expertise in. In the graph above, I attempt to provide a visualization and a language to give power back to devs to communicate what it is exactly that they do.
 
 <style>
 


### PR DESCRIPTION
It’s a weird world we live in. I almost get happy when I see typos, then I know somebody actually wrote it.

Fixed it in case the rest of the world sees it differently 😂