### PR TITLE
fix(site3): narrow search title from regex match to string

### DIFF
--- a/apps/site3/src/routes/+page.ts
+++ b/apps/site3/src/routes/+page.ts
@@ -15,7 +15,7 @@ const slugFromPath = (path: string) => {
 
 const extractTitle = (content: string, fallback: string) => {
 	const match = content.match(/^#\s+(.+)$/m)
-	return match ? match[1] : fallback
+	return match?.[1] ?? fallback
 }
 
 const stripMarkdown = (content: string) => {


### PR DESCRIPTION
RegExp capture groups are typed as string | undefined; use nullish coalescing so SearchItem.title stays a plain string.