### PR TITLE
feat(site3): add minimal sidebar and move search to a separate page

### DIFF
--- a/apps/site3/src/lib/components/docs-shell.svelte
+++ b/apps/site3/src/lib/components/docs-shell.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	import type { DocEntry } from '$lib/content'
+
+	import { browser } from '$app/environment'
+	import { afterNavigate } from '$app/navigation'
+	import { resolve } from '$app/paths'
+	import type { Component } from 'svelte'
+	import { onMount } from 'svelte'
+
+	let {
+		currentDoc,
+		currentSlug,
+		docs,
+	}: { currentDoc: DocEntry; currentSlug: string; docs: DocEntry[] } = $props()
+
+	let sidebarOpen = $state(false)
+	let isDesktop = $state(browser ? window.matchMedia('(min-width: 768px)').matches : false)
+
+	onMount(() => {
+		const mq = window.matchMedia('(min-width: 768px)')
+		const update = () => {
+			isDesktop = mq.matches
+		}
+		mq.addEventListener('change', update)
+		return () => mq.removeEventListener('change', update)
+	})
+
+	afterNavigate(() => {
+		sidebarOpen = false
+	})
+
+	const navInert = $derived(browser && !isDesktop && !sidebarOpen)
+
+	const Content = $derived(currentDoc.component as Component)
+
+	const proseArticleClass = [
+		'mx-auto max-w-prose px-4 py-8 md:px-6 lg:px-8',
+		'prose-blue dark:prose-invert',
+		'prose sm:prose-sm md:prose-base lg:prose-lg xl:prose-xl',
+		'prose-inline-code:rounded prose-inline-code:outline prose-inline-code:outline-stone-400 prose-code:before:content-none prose-code:after:content-none',
+		'prose-pre:border dark:prose-pre:border-neutral-700',
+	] as const
+</script>
+
+<div class="docs-shell flex h-dvh min-h-0 w-full flex-col overflow-hidden md:flex-row">
+	<div
+		class="flex shrink-0 items-center justify-between border-b border-stone-200 px-4 py-3 md:hidden dark:border-neutral-800"
+	>
+		<button
+			type="button"
+			class="rounded-md border border-stone-300 bg-white px-3 py-2 text-sm font-medium text-stone-800 shadow-sm transition hover:bg-stone-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:border-neutral-600 dark:bg-neutral-900 dark:text-stone-100 dark:hover:bg-neutral-800"
+			aria-controls="docs-sidebar-nav"
+			aria-expanded={sidebarOpen}
+			onclick={() => {
+				sidebarOpen = !sidebarOpen
+			}}
+		>
+			Documentation menu
+		</button>
+	</div>
+
+	{#if sidebarOpen}
+		<button
+			type="button"
+			class="fixed inset-0 z-30 bg-black/40 md:hidden"
+			aria-label="Close documentation menu"
+			onclick={() => {
+				sidebarOpen = false
+			}}
+		></button>
+	{/if}
+
+	<nav
+		id="docs-sidebar-nav"
+		class={[
+			'fixed inset-y-0 left-0 z-40 min-h-0 w-[min(92vw,24rem)] overflow-y-auto overscroll-y-contain border-r border-stone-200 bg-stone-50 transition-transform duration-200 ease-out dark:border-neutral-800 dark:bg-neutral-950',
+			'md:static md:z-auto md:h-full md:w-sm md:max-w-none md:shrink-0 md:translate-x-0 md:transform-none',
+			sidebarOpen ? 'translate-x-0' : '-translate-x-full',
+		]}
+		aria-label="Documentation"
+		inert={navInert}
+	>
+		<ul class="flex flex-col gap-0.5 p-4 md:py-8">
+			{#each docs as doc (doc.slug)}
+				<li>
+					<a
+						href={resolve('/docs/[...slug]', { slug: doc.slug })}
+						class={[
+							'block rounded-md px-3 py-2 text-sm transition',
+							doc.slug === currentSlug
+								? 'bg-blue-100 text-blue-900 dark:bg-blue-950 dark:text-blue-100'
+								: 'text-stone-800 hover:bg-stone-200/80 dark:text-stone-200 dark:hover:bg-neutral-800',
+						]}
+						aria-current={doc.slug === currentSlug ? 'page' : undefined}
+					>
+						{doc.title}
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</nav>
+
+	<main class="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-y-contain">
+		<article class={proseArticleClass}>
+			<Content />
+		</article>
+	</main>
+</div>

--- a/apps/site3/src/lib/content.ts
+++ b/apps/site3/src/lib/content.ts
@@ -3,13 +3,14 @@ import type { Component } from 'svelte'
 import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error'
 import { Ok, type Result } from 'wellcrafted/result'
 
-type Md = {
-	name: string
+export type DocEntry = {
 	component: Component
 	frontmatter: Record<string, unknown>
+	slug: string
+	title: string
 }
 
-type RawMd = { default: Component; frontmatter: Record<string, unknown> & { title: string } }
+type RawMd = { default: Component; frontmatter: Record<string, unknown> & { title?: string } }
 
 export const AppError = defineErrors({
 	DocMissing: ({ path }: { path: string }) => ({
@@ -27,54 +28,67 @@ export const AppError = defineErrors({
 })
 type AppError = InferErrors<typeof AppError>
 
+const normalizeSlug = (name: string) =>
+	name
+		.toLowerCase()
+		.replace(/\s+/g, '-')
+		.replace(/[^a-z0-9-]/g, '')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '')
+
+const titleFromSlug = (slug: string) =>
+	slug
+		.split('-')
+		.filter(Boolean)
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(' ')
+
 const rawModules = import.meta.glob<RawMd>(`/src/content/**/*.md`, { eager: true })
-const modules = Object.entries(rawModules).reduce(
-	(acc, [globPath, md]) => {
-		// const fullPath = projectRoot + globPath
+
+const buildDocEntries = (): DocEntry[] => {
+	const entries: DocEntry[] = []
+
+	for (const [globPath, md] of Object.entries(rawModules)) {
 		const parts = globPath.split('/')
 		const filename = parts.pop()!.replace('.md', '')
 		const name = filename === 'index' ? parts.pop()! : filename
-		const slug = name
-			.toLowerCase() // lowercase
-			.replace(/\s+/g, '-') // spaces → hyphens
-			.replace(/[^a-z0-9-]/g, '') // strip non-alphanumeric chars (keep a-z, 0-9, -)
-			.replace(/-+/g, '-') // collapse consecutive hyphens
-			.replace(/^-|-$/g, '') // trim leading/trailing hyphens
+		const slug = normalizeSlug(name)
 
-		if (slug) {
-			acc[slug] = {
-				name,
-				component: md.default,
-				frontmatter: md.frontmatter,
-				// path: fullPath,
-			}
-		}
+		if (!slug) continue
 
-		return acc
-	},
-	{} as Record<string, Md>,
-)
+		const title =
+			typeof md.frontmatter.title === 'string' && md.frontmatter.title.trim()
+				? md.frontmatter.title.trim()
+				: titleFromSlug(slug)
 
-export const getDoc = (slug: string): Result<Md, AppError> => {
-	try {
-		const module = Object.entries(modules).find(([path]) => {
-			const currentSlug = path
-				.replace(/^\/src\/content\//, '')
-				.replace(/\.md$/, '')
-				.replace(/\/index$/, '')
-			return slug === currentSlug
+		entries.push({
+			component: md.default,
+			frontmatter: md.frontmatter,
+			slug,
+			title,
 		})
+	}
 
-		if (!module) return AppError.DocNotFound({ path: slug })
+	return entries.sort((a, b) => {
+		const t = a.title.localeCompare(b.title, undefined, { sensitivity: 'base' })
+		if (t !== 0) return t
+		return a.slug.localeCompare(b.slug)
+	})
+}
 
-		const [, md] = module
+const sortedDocs = buildDocEntries()
 
-		// const validate
-		// if (docResult.metadata) {
-		// 	error(404)
-		// }
+const docsBySlug = new Map<string, DocEntry>(sortedDocs.map((d) => [d.slug, d]))
 
-		return Ok(md)
+export const listDocs = (): DocEntry[] => [...sortedDocs]
+
+export const getFirstDoc = (): DocEntry | undefined => sortedDocs[0]
+
+export const getDoc = (slug: string): Result<DocEntry, AppError> => {
+	try {
+		const doc = docsBySlug.get(slug)
+		if (!doc) return AppError.DocNotFound({ path: slug })
+		return Ok(doc)
 	} catch (e) {
 		return AppError.Unexpected({ cause: e })
 	}

--- a/apps/site3/src/routes/+layout.svelte
+++ b/apps/site3/src/routes/+layout.svelte
@@ -12,14 +12,4 @@
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
 <ModeWatcher />
 <Anchor />
-<article
-	class={[
-		'mx-auto max-w-prose',
-		'prose-blue dark:prose-invert',
-		'prose sm:prose-sm md:prose-base lg:prose-lg xl:prose-xl',
-		'prose-inline-code:rounded prose-inline-code:outline prose-inline-code:outline-stone-400 prose-code:before:content-none prose-code:after:content-none',
-		'prose-pre:border dark:prose-pre:border-neutral-700',
-	]}
->
-	{@render children()}
-</article>
+{@render children()}

--- a/apps/site3/src/routes/+page.svelte
+++ b/apps/site3/src/routes/+page.svelte
@@ -1,86 +1,13 @@
 <script lang="ts">
-	import { resolve } from '$app/paths'
-
-	import FlexSearch from 'flexsearch'
-	import { SvelteSet } from 'svelte/reactivity'
+	import DocsShell from '$lib/components/docs-shell.svelte'
 
 	let { data } = $props()
-
-	type Item = { content: string; slug: string; title: string }
-
-	const items = $derived(data.items)
-
-	const index = new FlexSearch.Document({
-		cache: true,
-		context: true,
-		document: {
-			id: 'slug',
-			field: ['title', 'content'],
-			store: ['title', 'slug'],
-		},
-		tokenize: 'forward',
-	})
-
-	$effect(() => {
-		for (const item of items) {
-			index.add(item)
-		}
-	})
-
-	let query = $state('')
-	let debounceTimer: null | ReturnType<typeof setTimeout> = null
-	let results = $state<Item[]>([])
-
-	const handleInput = (e: Event) => {
-		const value = (e.target as HTMLInputElement).value
-		query = value
-
-		if (debounceTimer) clearTimeout(debounceTimer)
-
-		if (value.length < 2) {
-			results = []
-			return
-		}
-
-		debounceTimer = setTimeout(async () => {
-			const searchResults = await index.search(value, { enrich: true, limit: 10 })
-			const seen = new SvelteSet<string>()
-			const found: Item[] = []
-
-			for (const field of searchResults) {
-				for (const result of field.result as unknown[]) {
-					const { id } = result as { id: string }
-					if (!seen.has(id)) {
-						seen.add(id)
-						const item = items.find((i: Item) => i.slug === id)
-						if (item) found.push(item)
-					}
-				}
-			}
-
-			results = found
-		}, 150)
-	}
 </script>
 
-<div class="mb-6">
-	<input
-		type="search"
-		placeholder="Search..."
-		bind:value={query}
-		oninput={handleInput}
-		class="w-full rounded border border-gray-300 px-4 py-2 dark:border-gray-700 dark:bg-gray-800"
-	/>
-</div>
-
-<ul class="flex flex-col">
-	{#each query.length >= 2 ? results : items as item (item.slug)}
-		<li>
-			<a href={resolve('/docs/[...slug]', { slug: item.slug })}>{item.title}</a>
-		</li>
-	{/each}
-</ul>
-
-{#if query.length >= 2 && results.length === 0}
-	<p class="text-gray-500">No results found for "{query}"</p>
+{#if data.currentDoc}
+	<DocsShell docs={data.docs} currentDoc={data.currentDoc} currentSlug={data.currentSlug} />
+{:else}
+	<p class="px-4 py-8 text-stone-600 dark:text-stone-400">
+		No documentation pages are available yet.
+	</p>
 {/if}

--- a/apps/site3/src/routes/+page.ts
+++ b/apps/site3/src/routes/+page.ts
@@ -1,60 +1,12 @@
-type SearchItem = { content: string; slug: string; title: string }
+import { getFirstDoc, listDocs } from '$lib/content'
 
-const slugFromPath = (path: string) => {
-	const name = path
-		.replace(/^\/src\/content\//, '')
-		.replace(/\.md$/, '')
-		.replace(/\/index$/, '')
-	return name
-		.toLowerCase()
-		.replace(/\s+/g, '-')
-		.replace(/[^a-z0-9-]/g, '')
-		.replace(/-+/g, '-')
-		.replace(/^-|-$/g, '')
-}
+export const load = () => {
+	const docs = listDocs()
+	const currentDoc = getFirstDoc()
 
-const extractTitle = (content: string, fallback: string) => {
-	const match = content.match(/^#\s+(.+)$/m)
-	return match?.[1] ?? fallback
-}
-
-const stripMarkdown = (content: string) => {
-	return content
-		.replace(/^#+\s+.+$/gm, '')
-		.replace(/```[\s\S]*?```/g, '')
-		.replace(/`[^`]+`/g, '')
-		.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-		.replace(/[*_~>]/g, '')
-		.replace(/^\s*[-*+]\s+/gm, '')
-		.replace(/^\s*\d+\.\s+/gm, '')
-		.replace(/\n{3,}/g, '\n\n')
-		.trim()
-}
-
-export const load = async () => {
-	const modules = import.meta.glob<string>(`/src/content/**/*.md`, {
-		eager: true,
-		import: 'default',
-		query: '?raw',
-	})
-
-	const items: SearchItem[] = []
-
-	for (const [path, content] of Object.entries(modules)) {
-		try {
-			const slug = slugFromPath(path)
-			const fallback = slug
-				.split('-')
-				.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-				.join(' ')
-			const title = extractTitle(content, fallback)
-			const stripped = stripMarkdown(content)
-
-			items.push({ content: stripped, slug, title })
-		} catch (e) {
-			console.error(`Error processing ${path}:`, e)
-		}
+	if (!currentDoc) {
+		return { currentDoc: null, currentSlug: '', docs }
 	}
 
-	return { items }
+	return { currentDoc, currentSlug: currentDoc.slug, docs }
 }

--- a/apps/site3/src/routes/docs/[...slug]/+page.svelte
+++ b/apps/site3/src/routes/docs/[...slug]/+page.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-	import { resolve } from '$app/paths'
+	import DocsShell from '$lib/components/docs-shell.svelte'
 
 	let { data } = $props()
 </script>
 
-<a href={resolve('/')}>back</a>
-
-<data.component />
+<DocsShell docs={data.docs} currentDoc={data.currentDoc} currentSlug={data.currentSlug} />

--- a/apps/site3/src/routes/docs/[...slug]/+page.ts
+++ b/apps/site3/src/routes/docs/[...slug]/+page.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-fallthrough */
-import { AppError, getDoc } from '$lib/content'
+import { AppError, getDoc, listDocs } from '$lib/content'
 
 import { error } from '@sveltejs/kit'
 
 export const load = async ({ params }) => {
+	const docs = listDocs()
 	const result = getDoc(params.slug)
 
 	if (result.error?.name === 'DocNotFound') {
@@ -28,7 +29,11 @@ export const load = async ({ params }) => {
 		}
 	}
 
-	return { component: result.data.component }
+	return {
+		currentDoc: result.data,
+		currentSlug: params.slug,
+		docs,
+	}
 }
 
 const checkEndpoint = async (url: string) => {

--- a/apps/site3/src/routes/search/+page.svelte
+++ b/apps/site3/src/routes/search/+page.svelte
@@ -70,11 +70,18 @@
 		'prose sm:prose-sm md:prose-base lg:prose-lg xl:prose-xl',
 	]}
 >
-	<h1
-		class="not-prose mb-6 text-2xl font-semibold tracking-tight text-stone-900 dark:text-stone-100"
-	>
-		Search
-	</h1>
+	<header class="not-prose mb-6">
+		<p class="mb-3 text-sm">
+			<a
+				href={resolve('/')}
+				class="inline-flex items-center gap-1.5 font-medium text-blue-600 transition hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+			>
+				<span aria-hidden="true">←</span>
+				Documentation
+			</a>
+		</p>
+		<h1 class="text-2xl font-semibold tracking-tight text-stone-900 dark:text-stone-100">Search</h1>
+	</header>
 
 	<div class="not-prose mb-6">
 		<label class="sr-only" for="doc-search">Search documentation</label>

--- a/apps/site3/src/routes/search/+page.svelte
+++ b/apps/site3/src/routes/search/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { resolve } from '$app/paths'
+
+	import FlexSearch from 'flexsearch'
+	import { SvelteSet } from 'svelte/reactivity'
+
+	let { data } = $props()
+
+	type Item = { content: string; slug: string; title: string }
+
+	const items = $derived(data.items)
+
+	const index = new FlexSearch.Document({
+		cache: true,
+		context: true,
+		document: {
+			id: 'slug',
+			field: ['title', 'content'],
+			store: ['title', 'slug'],
+		},
+		tokenize: 'forward',
+	})
+
+	$effect(() => {
+		for (const item of items) {
+			index.add(item)
+		}
+	})
+
+	let query = $state('')
+	let debounceTimer: null | ReturnType<typeof setTimeout> = null
+	let results = $state<Item[]>([])
+
+	const handleInput = (e: Event) => {
+		const value = (e.target as HTMLInputElement).value
+		query = value
+
+		if (debounceTimer) clearTimeout(debounceTimer)
+
+		if (value.length < 2) {
+			results = []
+			return
+		}
+
+		debounceTimer = setTimeout(async () => {
+			const searchResults = await index.search(value, { enrich: true, limit: 10 })
+			const seen = new SvelteSet<string>()
+			const found: Item[] = []
+
+			for (const field of searchResults) {
+				for (const result of field.result as unknown[]) {
+					const { id } = result as { id: string }
+					if (!seen.has(id)) {
+						seen.add(id)
+						const item = items.find((i: Item) => i.slug === id)
+						if (item) found.push(item)
+					}
+				}
+			}
+
+			results = found
+		}, 150)
+	}
+</script>
+
+<article
+	class={[
+		'mx-auto max-w-prose px-4 py-8 md:px-6 lg:px-8',
+		'prose-blue dark:prose-invert',
+		'prose sm:prose-sm md:prose-base lg:prose-lg xl:prose-xl',
+	]}
+>
+	<h1
+		class="not-prose mb-6 text-2xl font-semibold tracking-tight text-stone-900 dark:text-stone-100"
+	>
+		Search
+	</h1>
+
+	<div class="not-prose mb-6">
+		<label class="sr-only" for="doc-search">Search documentation</label>
+		<input
+			id="doc-search"
+			type="search"
+			placeholder="Search..."
+			bind:value={query}
+			oninput={handleInput}
+			class={[
+				'w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm',
+				'transition placeholder:text-stone-400',
+				'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600',
+				'dark:border-neutral-600 dark:bg-neutral-900 dark:text-stone-100 dark:placeholder:text-neutral-500',
+			]}
+		/>
+	</div>
+
+	<ul
+		class="not-prose flex flex-col gap-0.5 rounded-lg border border-stone-200 p-1 dark:border-neutral-800"
+	>
+		{#each query.length >= 2 ? results : items as item (item.slug)}
+			<li>
+				<a
+					href={resolve('/docs/[...slug]', { slug: item.slug })}
+					class={[
+						'block rounded-md px-3 py-2 text-sm text-stone-800 transition',
+						'hover:bg-stone-200/80 dark:text-stone-200 dark:hover:bg-neutral-800',
+						'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600',
+					]}
+				>
+					{item.title}
+				</a>
+			</li>
+		{/each}
+	</ul>
+
+	{#if query.length >= 2 && results.length === 0}
+		<p class="not-prose mt-4 text-sm text-stone-500 dark:text-neutral-400">
+			No results found for "{query}"
+		</p>
+	{/if}
+</article>

--- a/apps/site3/src/routes/search/+page.ts
+++ b/apps/site3/src/routes/search/+page.ts
@@ -1,0 +1,60 @@
+type SearchItem = { content: string; slug: string; title: string }
+
+const slugFromPath = (path: string) => {
+	const name = path
+		.replace(/^\/src\/content\//, '')
+		.replace(/\.md$/, '')
+		.replace(/\/index$/, '')
+	return name
+		.toLowerCase()
+		.replace(/\s+/g, '-')
+		.replace(/[^a-z0-9-]/g, '')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '')
+}
+
+const extractTitle = (content: string, fallback: string) => {
+	const match = content.match(/^#\s+(.+)$/m)
+	return match?.[1] ?? fallback
+}
+
+const stripMarkdown = (content: string) => {
+	return content
+		.replace(/^#+\s+.+$/gm, '')
+		.replace(/```[\s\S]*?```/g, '')
+		.replace(/`[^`]+`/g, '')
+		.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+		.replace(/[*_~>]/g, '')
+		.replace(/^\s*[-*+]\s+/gm, '')
+		.replace(/^\s*\d+\.\s+/gm, '')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim()
+}
+
+export const load = async () => {
+	const modules = import.meta.glob<string>(`/src/content/**/*.md`, {
+		eager: true,
+		import: 'default',
+		query: '?raw',
+	})
+
+	const items: SearchItem[] = []
+
+	for (const [path, content] of Object.entries(modules)) {
+		try {
+			const slug = slugFromPath(path)
+			const fallback = slug
+				.split('-')
+				.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+				.join(' ')
+			const title = extractTitle(content, fallback)
+			const stripped = stripMarkdown(content)
+
+			items.push({ content: stripped, slug, title })
+		} catch (e) {
+			console.error(`Error processing ${path}:`, e)
+		}
+	}
+
+	return { items }
+}


### PR DESCRIPTION
For now, I think it would be easier to focus on the shell, which is the sidebar, previous and next navigations, breadcrumbs, etc. and work on the search later. I've temporarily moved the search to a new page. 

Let me know what you think!

Sidebar:
<img width="1822" height="1185" alt="image" src="https://github.com/user-attachments/assets/3e3d4d84-da62-4ced-a7a4-d432949fd623" />

`/search`:
<img width="1822" height="1185" alt="image" src="https://github.com/user-attachments/assets/1e90a431-86de-4ad7-9377-543276135923" />
