### PR TITLE
fix(site): scope markdown link hover styles

### DIFF
--- a/apps/site/DESIGN.md
+++ b/apps/site/DESIGN.md
@@ -61,7 +61,7 @@ The docs article applies (see `(markdown)/+layout.svelte`):
 
 ```css
 prose sm:prose-sm md:prose-base lg:prose-lg xl:prose-xl
-prose-a:text-primary prose-a:decoration-primary/30 hover:prose-a:decoration-primary
+prose-a:text-primary prose-a:decoration-primary/30 prose-a:hover:decoration-primary
 prose-inline-code:rounded prose-inline-code:outline prose-inline-code:outline-border
 prose-code:before:content-none prose-code:after:content-none
 prose-pre:border prose-pre:border-border

--- a/apps/site/src/routes/(markdown)/+layout.svelte
+++ b/apps/site/src/routes/(markdown)/+layout.svelte
@@ -55,7 +55,7 @@
 			class={[
 				'mx-auto max-w-prose px-4 py-8 md:px-6 lg:px-8',
 				'prose sm:prose-sm md:prose-base lg:prose-lg xl:prose-xl',
-				'prose-a:text-primary prose-a:decoration-primary/30 hover:prose-a:decoration-primary',
+				'prose-a:text-primary prose-a:decoration-primary/30 prose-a:hover:decoration-primary',
 				'prose-inline-code:rounded prose-inline-code:outline prose-inline-code:outline-border prose-code:before:content-none prose-code:after:content-none',
 				'prose-pre:border prose-pre:border-border',
 				'dark:prose-invert',


### PR DESCRIPTION
Currently on main, when you hover over any markdown, all the links get hovered. This PR fixes it. 